### PR TITLE
Add gemini-beads extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Firestore Native](https://github.com/gemini-cli-extensions/firestore-native) - Provides a set of tools to interact with Firestore databases. It allows you to manage your databases, documents, and collections directly from the Gemini CLI, using natural language prompts.
 - [Run Long Command](https://github.com/stevenAthompson/run-long-command) - Provides Gemini CLI the ability to execute long running commands in the background asychronously by wrapping it in TMUX and injecting input.
 - [Self Command](https://github.com/stevenAthompson/self-command) - Allows Gemini CLI to send itself commands & prompts by wrapping it in TMUX and injecting input.
+- [gemini-beads](https://github.com/thoreinstein/gemini-beads) - Git-backed persistent memory and task management for Gemini CLI.
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
Adding gemini-beads, an extension that integrates the beads issue tracker to solve context loss in Gemini CLI sessions. It provides graph-based task management and persistent memory backed by Git.