### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@
 - [flutter](https://github.com/gemini-cli-extensions/flutter) - Help Gemini CLI create, build, test, and run Flutter apps.
 - [Firebase](https://github.com/gemini-cli-extensions/firebase) - Give the Gemini CLI more Firebase-specific capabilities and expertise.
 - [Firestore Native](https://github.com/gemini-cli-extensions/firestore-native) - Provides a set of tools to interact with Firestore databases. It allows you to manage your databases, documents, and collections directly from the Gemini CLI, using natural language prompts.
-- [Run Long Command](https://github.com/stevenAthompson/run-long-command) - Provides Gemini CLI the ability to execute long running commands in the background asychronously by wrapping it in TMUX and injecting input.
-- [Self Command](https://github.com/stevenAthompson/self-command) - Allows Gemini CLI to send itself commands & prompts by wrapping it in TMUX and injecting input.
+- [Self Command](https://github.com/stevenAthompson/self-command) - Allows the Gemini CLI to send commands to itself, run very long commands in the background and be woken, sleep for a specified amount of time, watch logs and receive notifications, etc by leveraging tmux. Reduces usage and improves reliability by avoiding loop detection. After installing the extension you must lauch gemini-cli into a tmux session named "gemini-cli".
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
Removed the run-long-command extension because it's functionality (and more) have now been moved into the self-command integration. Then updated the descriptions for self-command. 