### PR TITLE
Add ATXP — agent wallet, email, and 100+ paid MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 ## 3rd-Party Services
 
+- [ATXP](https://github.com/atxp-dev/atxp) - Give your Gemini CLI agent a wallet, email address, phone number, and 100+ paid MCP tools (web search, image gen, SMS, voice, LLM gateway). Self-register with `gemini extensions install https://github.com/atxp-dev/atxp` — no human login required, $5 free credits included.
 - [Figma](https://github.com/figma/figma-gemini-cli-extension) - Official Figma extension for Gemini CLI.
 - [Google Fonts](https://github.com/rodydavis/google-fonts-gemini-cli-extension) - Gemini CLI extension for Google Fonts + Material Icons and Symbols.
 - [GitLab](https://github.com/GitLab-Ecosystem/Gemini-CLI-Extensions) - Exposes custom `/gitlab:*` commands that map directly to GitLab's documented MCP tools for issues, merge requests, pipelines, and search.


### PR DESCRIPTION
## What this adds

[ATXP](https://github.com/atxp-dev/atxp) is a Gemini CLI extension that gives your agent a complete funded identity:

- **Wallet** (USDC on Base, Stripe top-up)
- **Email** (agent gets its own `@atxp.email` inbox)
- **Phone** (SMS + voice calls)
- **100+ MCP tools** — web search, image gen, music, video, X/Twitter search, LLM gateway

Install:
```bash
gemini extensions install https://github.com/atxp-dev/atxp
```

No human login required. Agents self-register, get $5 free credits, and pay per call from their own balance.

## Why it belongs in 3rd-Party Services

It fits the existing pattern (Figma, GitLab, Obsidian) — a third-party service integration via MCP. ATXP's MCP servers expose wallet/email/phone/tools functionality that extends what Gemini CLI can do autonomously.

The extension has the `gemini-cli-extension` topic tag on GitHub.