### PR TITLE
Add brooks-lint extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [Plan commands](https://github.com/jjdelorme/plan-commands) - Gemini CLI Extension with Custom Commands for plan, refine, implement.
 - [Jules](https://github.com/gemini-cli-extensions/jules) - Allows you to use the Gemini CLI to orchestrate the Jules asynchronous agent to perform coding tasks like bug fixing, refactoring, and dependency updates.
 - [adk-docs-ext](https://github.com/derailed-dash/adk-docs-ext) - ADK Docs Extension for Gemini CLI.
+- [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books. Diagnoses decay risks with structured findings (Symptom → Source → Consequence → Remedy).
 - [flutter](https://github.com/gemini-cli-extensions/flutter) - Help Gemini CLI create, build, test, and run Flutter apps.
 - [Firebase](https://github.com/gemini-cli-extensions/firebase) - Give the Gemini CLI more Firebase-specific capabilities and expertise.
 - [Firestore Native](https://github.com/gemini-cli-extensions/firestore-native) - Provides a set of tools to interact with Firestore databases. It allows you to manage your databases, documents, and collections directly from the Gemini CLI, using natural language prompts.


### PR DESCRIPTION
Add [brooks-lint](https://github.com/hyhmrright/brooks-lint) to the Development section.

brooks-lint provides AI code reviews grounded in six classic software engineering books (The Mythical Man-Month, Code Complete, Refactoring, A Philosophy of Software Design, Clean Code, The Pragmatic Programmer). It diagnoses decay risks with structured findings following the pattern: Symptom → Source → Consequence → Remedy.

It supports Gemini CLI via `gemini-extension.json` and can be installed with:
```
gemini extensions install https://github.com/hyhmrright/brooks-lint
```