### PR TITLE
Add TokRepo Gemini CLI extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [Google Fonts](https://github.com/rodydavis/google-fonts-gemini-cli-extension) - Gemini CLI extension for Google Fonts + Material Icons and Symbols.
 - [GitLab](https://github.com/GitLab-Ecosystem/Gemini-CLI-Extensions) - Exposes custom `/gitlab:*` commands that map directly to GitLab's documented MCP tools for issues, merge requests, pipelines, and search.
 - [Obsidian](https://github.com/thoreinstein/gemini-obsidian) - Connect Gemini to your Obsidian vault through a local RAG MCP server with `/obsidian:*` commands to interact with your vault.
+- [TokRepo](https://github.com/henu-wang/tokrepo-gemini-extension) - Search TokRepo from Gemini CLI to find installable skills, prompts, MCP configs, and workflows with the bundled TokRepo MCP server.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server & AI agent skill. 20 tools for followers, tweets, replies, mentions, lists, hashtags, spaces & more.
 ## Utilities
 


### PR DESCRIPTION
This adds TokRepo as an installable Gemini CLI extension.

Why it fits:
- the linked repo is a dedicated Gemini extension with `gemini-extension.json` at the repo root
- it bundles the TokRepo MCP server so Gemini CLI can search installable skills, prompts, MCP configs, and workflows
- it gives users a direct install target instead of a generic product link

Install:
`gemini extension install https://github.com/henu-wang/tokrepo-gemini-extension`

Happy to tweak the description or move it to a different section if that is a better fit.