### PR TITLE
Add gemini-discord to Automation & Remote Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 - [pyATS](https://github.com/automateyournetwork/pyATS_GeminiCLI_Extension) - pyATS integration for network testing.
 - [**gemini-discord**](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 
-
 ## 3rd-Party Services
 
 - [ATXP](https://github.com/atxp-dev/atxp) - Give your Gemini CLI agent a wallet, email address, phone number, and 100+ paid MCP tools (web search, image gen, SMS, voice, LLM gateway). Self-register with `gemini extensions install https://github.com/atxp-dev/atxp` — no human login required, $5 free credits included.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - [Listen](https://github.com/automateyournetwork/GeminiCLI_Listen_Extension) - Run Gemini CLI as a server with /listen commands.
 - [Screenshare](https://github.com/automateyournetwork/GeminiCLI_ScreenShare_Extension) - Screen sharing via MCP and custom slash commands.
 - [pyATS](https://github.com/automateyournetwork/pyATS_GeminiCLI_Extension) - pyATS integration for network testing.
-- [**gemini-discord**](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI into an always-on Discord agent and server admin.
+- [**gemini-discord**](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 
 
 ## 3rd-Party Services

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 - [Listen](https://github.com/automateyournetwork/GeminiCLI_Listen_Extension) - Run Gemini CLI as a server with /listen commands.
 - [Screenshare](https://github.com/automateyournetwork/GeminiCLI_ScreenShare_Extension) - Screen sharing via MCP and custom slash commands.
 - [pyATS](https://github.com/automateyournetwork/pyATS_GeminiCLI_Extension) - pyATS integration for network testing.
+- [**gemini-discord**](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI into an always-on Discord agent and server admin.
+
 
 ## 3rd-Party Services
 


### PR DESCRIPTION
Added gemini-discord, a Gemini CLI extension that turns your local agent into an always-on Discord presence that also doubles as your personal server admin.