### PR TITLE
feat: add TWZRD Agent Intel to 3rd-Party Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time market intelligence, ML options pricing, and news bias analysis. Free, no API key. Remote endpoint: https://heliumtrades.com/mcp
 - [Onplana](https://github.com/Onplana/onplana-mcp-server) - Connect Gemini CLI and Code Assist to your Onplana project portfolio. 27 tools (14 read, 13 write), OAuth 2.0 with Dynamic Client Registration. Install: `gemini extensions install https://github.com/Onplana/onplana-mcp-server`.
 - [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agent wallet identity on Solana. Verify agent wallets before x402 micropayments. 4 free tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt. Remote endpoint: https://intel.twzrd.xyz/mcp
+
 ## Utilities
 
 - [Gemini Notifier](https://github.com/thoreinstein/gemini-notifier) - A Gemini extension to send native system-level notifications when Gemini requests permissions.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server & AI agent skill. 20 tools for followers, tweets, replies, mentions, lists, hashtags, spaces & more.
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time market intelligence, ML options pricing, and news bias analysis. Free, no API key. Remote endpoint: https://heliumtrades.com/mcp
 - [Onplana](https://github.com/Onplana/onplana-mcp-server) - Connect Gemini CLI and Code Assist to your Onplana project portfolio. 27 tools (14 read, 13 write), OAuth 2.0 with Dynamic Client Registration. Install: `gemini extensions install https://github.com/Onplana/onplana-mcp-server`.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agent wallet identity on Solana. Verify agent wallets before x402 micropayments. 4 free tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt. Remote endpoint: https://intel.twzrd.xyz/mcp
 ## Utilities
 
 - [Gemini Notifier](https://github.com/thoreinstein/gemini-notifier) - A Gemini extension to send native system-level notifications when Gemini requests permissions.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the 3rd-Party Services section.

**What it is**: A production MCP server for AI agent trust scoring on Solana. Verifies agent wallet identity before x402 micropayments.

**Why it fits here**: It's a remote hosted 3rd-party service exposed via MCP — exactly the kind of tool this section covers. 4 free tools available via streamable-http transport.

**MCP Config**:
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`