### PR TITLE
Add Lusha (B2B data enrichment) to 3rd-Party Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [Figma](https://github.com/figma/figma-gemini-cli-extension) - Official Figma extension for Gemini CLI.
 - [Google Fonts](https://github.com/rodydavis/google-fonts-gemini-cli-extension) - Gemini CLI extension for Google Fonts + Material Icons and Symbols.
 - [GitLab](https://github.com/GitLab-Ecosystem/Gemini-CLI-Extensions) - Exposes custom `/gitlab:*` commands that map directly to GitLab's documented MCP tools for issues, merge requests, pipelines, and search.
+- [Lusha](https://github.com/lusha-oss/lusha-mcp-plugin) - Find and enrich B2B contacts and companies with verified emails, direct dials, mobile numbers, and real-time buying signals. Bundles 4 prospecting skills plus a remote MCP server, with OAuth sign-in. Install: `gemini extensions install https://github.com/lusha-oss/lusha-mcp-plugin`.
 - [Obsidian](https://github.com/thoreinstein/gemini-obsidian) - Connect Gemini to your Obsidian vault through a local RAG MCP server with `/obsidian:*` commands to interact with your vault.
 - [TokRepo](https://github.com/henu-wang/tokrepo-gemini-extension) - Search TokRepo from Gemini CLI to find installable skills, prompts, MCP configs, and workflows with the bundled TokRepo MCP server.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server & AI agent skill. 20 tools for followers, tweets, replies, mentions, lists, hashtags, spaces & more.


### PR DESCRIPTION
Adds [Lusha](https://github.com/lusha-oss/lusha-mcp-plugin) under **3rd-Party Services**.

Lusha is a B2B data enrichment extension: find and enrich contacts and companies with verified emails, direct dials, mobile numbers, and real-time buying signals. It bundles 4 prospecting skills plus a remote MCP server (OAuth sign-in), and installs with:

```
gemini extensions install https://github.com/lusha-oss/lusha-mcp-plugin
```

It also works in Antigravity CLI via `agy plugin install https://github.com/lusha-oss/lusha-mcp-plugin`.