### PR TITLE
Add Unity-MCP, Godot-MCP, and Unreal-MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@
 - [Firebase](https://github.com/gemini-cli-extensions/firebase) - Give the Gemini CLI more Firebase-specific capabilities and expertise.
 - [Firestore Native](https://github.com/gemini-cli-extensions/firestore-native) - Provides a set of tools to interact with Firestore databases. It allows you to manage your databases, documents, and collections directly from the Gemini CLI, using natural language prompts.
 - [Maestro](https://github.com/josstei/maestro-gemini) - Turn Gemini CLI into a multi-agent platform — 12 specialized subagents, parallel dispatch, 4-phase orchestration, and standalone dev tools for code review, debugging, security, and performance.
+- [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) - Open-source MCP server connecting AI agents to the Unity Editor and runtime, with 100+ built-in tools.
+- [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) - Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
+- [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) - Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
Adds Unity-MCP, Godot-MCP, and Unreal-MCP — open-source (Apache-2.0) MCP servers connecting AI coding agents including Gemini CLI to their game engines' editors/runtimes via Anthropic's Model Context Protocol. Maintained at github.com/IvanMurzak/. Happy to adjust to match your conventions — thanks for maintaining this list!