### PR TITLE
Add Find MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) - Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
 - [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) - Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).
 - [PickySteve](https://github.com/KernelLord/pickysteve) - Skill router and context picker for coding agents: a cheap local model retrieves and reranks the right skill (BM25 + embeddings, cross-encoder rerank), gated by a fail-closed prompt-injection scanner that checks both the request and every retrieved doc. Wires into Gemini CLI as an MCP stdio server via a one-command installer (`~/.gemini/settings.json`); runs offline on local Ollama by default.
+- [Find MCP](https://github.com/agentage/find-mcp) - Search 17,000+ MCP servers from the official MCP registry (registry.modelcontextprotocol.io). Remote endpoint: `https://catalog.agentage.io/mcp`. Install: `gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp`, or stdio via `npx -y @agentage/find-mcp`.
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
Adds **Find MCP** to the `## Development` section (bottom of the list, alongside the other MCP discovery/router servers like PickySteve and TokRepo).

- What: MCP server for discovering other MCP servers - searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io).
- Where: `README.md`, `## Development` section, new bottom entry.
- Links: [GitHub](https://github.com/agentage/find-mcp) · npm `@agentage/find-mcp` · remote endpoint `https://catalog.agentage.io/mcp` · web UI [catalog.agentage.io/mcp](https://catalog.agentage.io/mcp) · official registry entry `io.agentage/find-mcp`.

Disclosure: I maintain Find MCP.
