### PR TITLE
Add Meanwhile optional side-quest extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI that strips AI writing patterns from content before publishing: sycophantic openers, stock vocabulary, hedging stacks, em-dash overuse. Code blocks, URLs, and technical terms pass through unchanged. Pipe mode for scripting: `cat draft.md | unslop --stdin`. `npm install -g unslop`.
 - [Subnet calculator](https://github.com/automateyournetwork/GeminiCLI_SubnetCalculator_Extension) - An extension for GeminiCLI that performs subnet calculation.
 - [Packet Buddy](https://github.com/automateyournetwork/GeminiCLI_Packet_Buddy_Extension) - A Gemini CLI extension that uses RAG and MCP and Custom Slash Commands to analyze packet captures.
+- [**Meanwhile**](https://github.com/vaddisrinivas/meanwhile) - Offers one optional, bounded focus, recovery, learning, play, or reality-check quest while Gemini CLI continues substantial work. No account, telemetry, or completion tracking.
 
 ## Development
 


### PR DESCRIPTION
Adds Meanwhile to the Gemini CLI extensions list.

Repository: https://github.com/vaddisrinivas/meanwhile
Install: `gemini extensions install https://github.com/vaddisrinivas/meanwhile --consent`

Meanwhile offers one optional, bounded focus, recovery, learning, play, or reality-check quest while Gemini CLI continues substantial work. It is MIT-licensed, catalogue-backed, and requires no account, callback, cookies, telemetry, or completion tracking.

Validation:
- Clean-profile Gemini CLI install succeeded
- Extension manifest at repository root
- Skill at `skills/meanwhile/SKILL.md`
- `git diff --check` passed