### PR TITLE
Add ArmorGemini to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 - [PickySteve](https://github.com/KernelLord/pickysteve) - Skill router and context picker for coding agents: a cheap local model retrieves and reranks the right skill (BM25 + embeddings, cross-encoder rerank), gated by a fail-closed prompt-injection scanner that checks both the request and every retrieved doc. Wires into Gemini CLI as an MCP stdio server via a one-command installer (`~/.gemini/settings.json`); runs offline on local Ollama by default.
 - [Find MCP](https://github.com/agentage/find-mcp) - Search 17,000+ MCP servers from the official MCP registry (registry.modelcontextprotocol.io). Remote endpoint: `https://catalog.agentage.io/mcp`. Install: `gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp`, or stdio via `npx -y @agentage/find-mcp`.
 - [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for Gemini CLI and other AI agents, with durable cross-session recall and no account or API key. Install: `gemini extensions install https://github.com/Lians-ai/Lians`.
+- [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
## What

Adds [ArmorGemini](https://github.com/armoriq/armorGemini) to the **Development** section.

## Why here

ArmorGemini is intent-based security enforcement for the Gemini CLI: every tool call is checked against an ArmorIQ policy at `BeforeTool` / `AfterTool` hook time. It sits in the same shape as Google's own [`security`](https://github.com/gemini-cli-extensions/security) extension already in this section: security-focused, wraps development workflows, evaluates code/actions before they run. Google's extension finds vulnerabilities in code; ours enforces policy at the tool-call layer.

## Entry (matches the existing single-line format used in this section)

```
- [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
```

## Repo hygiene checklist

Per CONTRIBUTING.md the extension has to actually be a Gemini CLI extension. Confirmations:

- Public GitHub repository
- MIT-licensed
- `gemini-cli-extension` topic set on the repo's About section
- `gemini-extension.json` manifest at repo root (name `armorgemini`, version `0.2.0`, description matches gallery card)
- `.gemini/settings.json` hooks + `.gemini/commands/armor/*.toml` custom commands ship with the repo, wired by the install script
- LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, README.md all present at root
- Repo also carries a custom social preview image and a working install path

Entry added at the bottom of the Development section per CONTRIBUTING.md.
