### PR TITLE
Add deja to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Find MCP](https://github.com/agentage/find-mcp) - Search 17,000+ MCP servers from the official MCP registry (registry.modelcontextprotocol.io). Remote endpoint: `https://catalog.agentage.io/mcp`. Install: `gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp`, or stdio via `npx -y @agentage/find-mcp`.
 - [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for Gemini CLI and other AI agents, with durable cross-session recall and no account or API key. Install: `gemini extensions install https://github.com/Lians-ai/Lians`.
 - [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
+- [deja](https://github.com/vshulcz/deja-vu) - Searches the coding sessions already on your disk — Gemini CLI plus nineteen other tools — so a new session can recall work from before deja was installed. Local Go binary, BM25, no LLM and no account.
 
 ## Cloud & Dev Tools
 


### PR DESCRIPTION
deja searches the coding sessions already on disk — Gemini CLI plus nineteen other tools — so a new session can recall work from before it was installed. Local Go binary, BM25, no LLM and no account.

Added to the bottom of Development, next to the other memory extensions.